### PR TITLE
ansibleapp-base arbitrary uid support; example arbitrary uid project

### DIFF
--- a/ansibleapp-base/Dockerfile
+++ b/ansibleapp-base/Dockerfile
@@ -9,9 +9,23 @@ RUN yum -y update \
 RUN echo "localhost ansible_connection=local" >> /etc/ansible/hosts
 RUN sed -i 's|#roles_path.*$|roles_path = /opt/ansible/roles|' /etc/ansible/ansible.cfg
 
-RUN mkdir /opt/ansibleapp
+COPY user_setup /tmp/
+
+ENV APP_ROOT=/opt/ansibleapp \
+    USER_NAME=ansibleapp \
+    USER_UID=1001
+
+RUN mkdir -p ${APP_ROOT} ${APP_ROOT}/etc /.kube /.ansible && \
+    chmod -R ug+x ${APP_ROOT} ${APP_ROOT}/etc /tmp/user_setup && \
+    chmod -R g+rw /.kube /.ansible && \
+    /tmp/user_setup
 
 COPY oc-login.sh /usr/bin
 COPY entrypoint.sh /usr/bin
+
+USER ${USER_UID}
+RUN sed "s@${USER_NAME}:x:${USER_UID}:@${USER_NAME}:x:\${USER_ID}:@g" /etc/passwd > ${APP_ROOT}/etc/passwd.template
+USER root
+RUN userdel ${USER_NAME} 
 
 ENTRYPOINT ["entrypoint.sh"]

--- a/ansibleapp-base/entrypoint.sh
+++ b/ansibleapp-base/entrypoint.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 ANSIBLEAPP_ACTION=$1
+USER_ID=$(id -u)
 shift
 playbooks=/opt/ansibleapp/actions
+
+if [ ${USER_UID} != ${USER_ID} ]; then
+sed "s@${USER_NAME}:x:\${USER_ID}:@${USER_NAME}:x:${USER_ID}:@g" ${APP_ROOT}/etc/passwd.template > /etc/passwd
+fi
 
 oc-login.sh
 

--- a/ansibleapp-base/user_setup
+++ b/ansibleapp-base/user_setup
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -x
+useradd -l -u ${USER_UID} -r -g 0 -d ${APP_ROOT} -s /sbin/nologin -c "${USER_NAME} application user" ${USER_NAME}
+chown -R ${USER_UID}:0 ${APP_ROOT}
+find ${APP_ROOT} -type d -exec chmod g+x {} +
+chmod -R g+w ${APP_ROOT} /etc/passwd

--- a/helloworld-ansibleapp/Dockerfile
+++ b/helloworld-ansibleapp/Dockerfile
@@ -1,0 +1,17 @@
+FROM ansibleapp/ansibleapp-base
+
+# MAINTAINER {{ $MAINTAINER }}
+
+LABEL "com.redhat.ansibleapp.version"="0.1.0"
+LABEL "com.redhat.ansibleapp.spec"=\
+"aWQ6IDM1ZWFkNGU4LWNmMWYtNDkwOS1iYjFiLWI5ODFmNGViMzE0MgpuYW1lOiBqY3Bvd2VybWFj\
+L2hlbGxvd29ybGQtYW5zaWJsZWFwcApkZXNjcmlwdGlvbjogSGVsbG8gV29ybGQgbmdpbnggCmJp\
+bmRhYmxlOiBmYWxzZQphc3luYzogInVuc3VwcG9ydGVkIgpwYXJhbWV0ZXJzOgogIC0gbmFtZTog\
+bWVzc2FnZSAKICAgIGRlc2NyaXB0aW9uOiBzYXkgc29tZXRoaW5nIHRvIG5naW54IAogICAgdHlw\
+ZTogc3RyaW5nCg=="
+ADD ansible /opt/ansible
+ADD ansibleapp /opt/ansibleapp
+
+RUN useradd -u 1001 -r -g 0 -M -b /opt/ansibleapp -s /sbin/nologin -c "ansibleapp user" ansibleapp
+RUN chown -R 1001:0 /opt/{ansible,ansibleapp}
+USER 1001

--- a/helloworld-ansibleapp/ansible/ansible.cfg
+++ b/helloworld-ansibleapp/ansible/ansible.cfg
@@ -1,0 +1,2 @@
+# Set any ansible.cfg overrides in this file.
+# See: https://docs.ansible.com/ansible/intro_configuration.html#explanation-of-values-by-section

--- a/helloworld-ansibleapp/ansible/container.yml
+++ b/helloworld-ansibleapp/ansible/container.yml
@@ -1,0 +1,14 @@
+version: "2"
+services:
+    web:
+        image: centos:7
+        ports: 
+            - "8080:8080"
+        expose:
+            - 8080
+        user: nginx
+        command: ['/usr/sbin/nginx','-c','/opt/app-root/etc/nginx.conf']
+        entrypoint: ['/usr/bin/entrypoint']
+        environment:
+            - "MESSAGE={{ '{{ message }}' }}"
+registries: {}

--- a/helloworld-ansibleapp/ansible/main.yml
+++ b/helloworld-ansibleapp/ansible/main.yml
@@ -1,0 +1,105 @@
+---
+- hosts: web 
+  gather_facts: false
+  vars_files:
+      - vars.yml
+  tasks:
+
+# ----------------------------
+# Install Packages
+# ----------------------------
+
+    - name: Install EPEL 
+      yum:
+        name: epel-release 
+        state: present
+
+    - name: Install nginx 
+      yum:
+        name: "{{ item }}" 
+        state: present
+      with_items:
+        - nginx
+        - sudo
+
+
+# ----------------------------
+# Create User
+# ----------------------------
+# Generic user that will be used when running
+# this container 
+# ----------------------------
+
+    - name: Create User
+      user:
+        name: "{{ username }}"
+        uid: "{{ uid }}"
+        group: root
+        shell: /sbin/nologin
+        createhome: False
+        home: "{{ app_root }}"
+        system: True
+
+
+# ----------------------------
+# Nginx and docker logging 
+# ----------------------------
+# This is pattern is used in the offical
+# nginx docker image
+# ----------------------------
+
+    - name: Create symbolic link
+      file: 
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+        state: link
+        force: True
+      with_items:
+        - { src: "/dev/stdout", dest: "/var/log/nginx/access.log" }
+        - { src: "/dev/stderr", dest: "/var/log/nginx/error.log" }
+
+    - name: Create Directories
+      file:
+        dest: "{{ item.dest }}"
+        state: directory
+        recurse: True
+        owner: "{{ username }}"
+        group: root
+        mode: "{{ item.mode }}"
+      with_items:
+        - { dest: "{{ app_root }}", mode: "g+rw" }
+        - { dest: "{{ app_root }}/bin", mode: "ug+x" }
+        - { dest: "{{ app_root }}/src", mode: "g+rw" }
+        - { dest: "{{ app_root }}/etc", mode: "g+rw" }
+        - { dest: "{{ app_root }}/html", mode: "g+rw" }
+        - { dest: "/.ansible", mode: "g+rw" }
+        - { dest: "/var/lib/nginx", mode: "ug+rwx" }
+        - { dest: "/var/log/nginx", mode: "ug+rwx" }
+        - { dest: "/run", mode: "ug+rw" }
+
+    - name: Create Image Entrypoint
+      template:
+        src: templates/entrypoint.j2
+        dest: /usr/bin/entrypoint
+        owner: "{{ username }}"
+        group: root
+        mode: "ug+x"
+
+    - name: Create nginx Configuration 
+      template:
+        src: templates/nginx.conf.j2
+        dest: "{{ app_root }}/etc/nginx.conf"
+        owner: "{{ username }}"
+        group: root
+        mode: "g+rw"
+
+    - name: Allow root group permissions to /etc/passwd
+      file:
+        dest: "/etc/passwd"
+        state: file
+        mode: "g+w"
+
+    - name: Create passwd template
+      shell: 'sed "s@{{ username }}:x:{{ uid }}:@{{ username }}:x:\${USER_ID}:@g" /etc/passwd > {{ app_root }}/etc/passwd.template'
+      become: True
+      become_user: "{{ username }}"

--- a/helloworld-ansibleapp/ansible/meta.yml
+++ b/helloworld-ansibleapp/ansible/meta.yml
@@ -1,0 +1,33 @@
+galaxy_info:
+  author: Your name
+  description: Describe your awesome application here.
+  company: Your company
+
+  # If the issue tracker for your role is not on GitHub, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: 
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: license (GPLv2, CC-BY, etc)
+
+  min_ansible_container_version: 0.3.0
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If travis integration is cofigured, only notification for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+
+  tags: []
+    # List tags for your app here, one per line. A tag is a keyword that describes and categorizes the app.
+    # Users will find your app by searching for tags. Be sure to remove the '[]' above.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters. Maximum 20 tags.

--- a/helloworld-ansibleapp/ansible/requirements.txt
+++ b/helloworld-ansibleapp/ansible/requirements.txt
@@ -1,0 +1,3 @@
+# These are the python requirements for your Ansible Container builder.
+# You do not need to include Ansible itself in this file.
+docker-py==1.10.6

--- a/helloworld-ansibleapp/ansible/requirements.yml
+++ b/helloworld-ansibleapp/ansible/requirements.yml
@@ -1,0 +1,5 @@
+# Install Ansible Roles
+# ---------------------
+# When the build process starts `ansible-galaxy install -r requirements.yml` is executed
+# using this file. Follow the instructions at http://docs.ansible.com/ansible/galaxy.html
+# to include any roles you want intalled prior to running main.yml.

--- a/helloworld-ansibleapp/ansible/roles/helloworld-ansibleapp-openshift/README
+++ b/helloworld-ansibleapp/ansible/roles/helloworld-ansibleapp-openshift/README
@@ -1,0 +1,41 @@
+Helloworld-Ansibleapp-Openshift
+===
+
+Automates the deployment of helloworld-ansibleapp to Openshift.
+
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Running helloworld-ansibleapp-openshift is easy! Here's a sample playbook:
+
+    - hosts: localhost 
+      gather_facts: no
+      connection: local
+      roles:
+         - { role: helloworld-ansibleapp-openshift }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/helloworld-ansibleapp/ansible/roles/helloworld-ansibleapp-openshift/defaults/main.yml
+++ b/helloworld-ansibleapp/ansible/roles/helloworld-ansibleapp-openshift/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# defaults for helloworld-ansibleapp-openshift
+
+playbook_debug: no

--- a/helloworld-ansibleapp/ansible/roles/helloworld-ansibleapp-openshift/library/oso_deployment.py
+++ b/helloworld-ansibleapp/ansible/roles/helloworld-ansibleapp-openshift/library/oso_deployment.py
@@ -1,0 +1,352 @@
+#!/usr/bin/python
+#
+# Copyright 2016 Ansible by Red Hat
+#
+# This file is part of ansible-container
+#
+
+DOCUMENTATION = '''
+
+module: oso_deployment
+
+short_description: Start, cancel or retry a deployment on a Kubernetes or OpenShift cluster.
+
+description:
+  - Start, cancel or retry a deployment on a Kubernetes or OpenShift cluster by setting the C(state) to I(present) or
+    I(absent).
+  - Supports check mode. Use check mode to view a list of actions the module will take.
+
+options:
+
+'''
+
+EXAMPLES = '''
+'''
+
+RETURN = '''
+'''
+import logging
+import logging.config
+
+from ansible.module_utils.basic import *
+
+logger = logging.getLogger('oso_deployment')
+
+LOGGING = (
+    {
+        'version': 1,
+        'disable_existing_loggers': True,
+        'handlers': {
+            'null': {
+                'level': 'DEBUG',
+                'class': 'logging.NullHandler',
+            },
+            'file': {
+                'level': 'DEBUG',
+                'class': 'logging.FileHandler',
+                'filename': 'ansible-container.log'
+            }
+        },
+        'loggers': {
+            'oso_deployment': {
+                'handlers': ['file'],
+                'level': 'INFO',
+            },
+            'container': {
+                'handlers': ['file'],
+                'level': 'INFO',
+            },
+            'compose': {
+                'handlers': [],
+                'level': 'INFO'
+            },
+            'docker': {
+                'handlers': [],
+                'level': 'INFO'
+            }
+        },
+    }
+)
+
+
+class DeploymentManager(object):
+
+    def __init__(self):
+
+        self.arg_spec = dict(
+            project_name=dict(type='str', aliases=['namespace'], required=True),
+            state=dict(type='str', choices=['present', 'absent'], default='present'),
+            labels=dict(type='dict'),
+            deployment_name=dict(type='str', aliases=['name']),
+            recreate=dict(type='bool', default=False),
+            replace=dict(type='bool', default=True),
+            replicas=dict(type='int', default=1),
+            containers=dict(type='list'),
+            strategy=dict(type='str', default='Rolling', choices=['Recreate', 'Rolling']),
+            volumes=dict(type='list'),
+        )
+
+        self.module = AnsibleModule(self.arg_spec,
+                                    supports_check_mode=True)
+
+        self.project_name = None
+        self.state = None
+        self.labels = None
+        self.deployment_name = None
+        self.replace = None
+        self.replicas = None
+        self.containers = None
+        self.strategy = None
+        self.recreate = None
+        self.volumes = None
+        self.api = None
+        self.check_mode = self.module.check_mode
+        self.debug = self.module._debug
+
+    def exec_module(self):
+
+        for key in self.arg_spec:
+            setattr(self, key, self.module.params.get(key))
+
+        if self.debug:
+            LOGGING['loggers']['container']['level'] = 'DEBUG'
+            LOGGING['loggers']['oso_deployment']['level'] = 'DEBUG'
+        logging.config.dictConfig(LOGGING)
+
+        self.api = OriginAPI(self.module)
+
+        actions = []
+        changed = False
+        deployments = dict()
+        results = dict()
+
+        project_switch = self.api.set_project(self.project_name)
+        if not project_switch:
+            actions.append("Create project %s" % self.project_name)
+            if not self.check_mode:
+                self.api.create_project(self.project_name)
+
+        if self.state == 'present':
+            deployment = self.api.get_resource('dc', self.deployment_name)
+            if not deployment:
+                template = self._create_template()
+                changed = True
+                actions.append("Create deployment %s" % self.deployment_name)
+                if not self.check_mode:
+                    self.api.create_from_template(template=template)
+            elif deployment and self.recreate:
+                actions.append("Delete deployment %s" % self.deployment_name)
+                changed = True
+                template = self._create_template()
+                if not self.check_mode:
+                    self.api.delete_resource('dc', self.deployment_name)
+                    self.api.create_from_template(template=template)
+            elif deployment and self.replace:
+                template = self._create_template()
+                template['status'] = dict(latestVersion=deployment['status']['latestVersion'] + 1)
+                changed = True
+                actions.append("Update deployment %s" % self.deployment_name)
+                if not self.check_mode:
+                    self.api.replace_from_template(template=template)
+
+            deployments[self.deployment_name.replace('-', '_') + '_deployment'] = self.api.get_resource('dc', self.deployment_name)
+
+        elif self.state == 'absent':
+            if self.api.get_resource('dc', self.deployment_name):
+                changed = True
+                actions.append("Delete deployment %s" % self.deployment_name)
+                if not self.check_mode:
+                    self.api.delete_resource('dc', self.deployment_name)
+
+        results['changed'] = changed
+        if self.check_mode:
+            results['actions'] = actions
+
+        if deployments:
+            results['ansible_facts'] = deployments
+
+        self.module.exit_json(**results)
+
+    def _create_template(self):
+
+        for container in self.containers:
+            if container.get('env'):
+                container['env'] = self._env_to_list(container['env'])
+
+        template = dict(
+            apiVersion="v1",
+            kind="DeploymentConfig",
+            metadata=dict(
+                name=self.deployment_name,
+            ),
+            spec=dict(
+                template=dict(
+                    metadata=dict(),
+                    spec=dict(
+                        containers=self.containers
+                    )
+                ),
+                replicas=self.replicas,
+                strategy=dict(
+                    type=self.strategy,
+                ),
+            )
+        )
+
+        if self.volumes:
+            template['spec']['template']['spec']['volumes'] = self.volumes
+
+        if self.labels:
+            template['metadata']['labels'] = self.labels
+            template['spec']['template']['metadata']['labels'] = self.labels
+
+        return template
+
+    @staticmethod
+    def _env_to_list(env_variables):
+        result = []
+        for name, value in env_variables.items():
+            result.append(dict(
+                name=name,
+                value=value
+            ))
+        return result
+
+
+#The following will be included by `ansble-container shipit` when cloud modules are copied into the role library path.
+
+import re
+import json
+
+
+class OriginAPI(object):
+
+    def __init__(self, module, target="oc"):
+        self.target = target
+        self.module = module
+
+    @staticmethod
+    def use_multiple_deployments(services):
+        '''
+        Inspect services and return True if the app supports multiple replica sets.
+
+        :param services: list of docker-compose service dicts
+        :return: bool
+        '''
+        multiple = True
+        for service in services:
+            if not service.get('ports'):
+                multiple = False
+            if service.get('volumes_from'):
+                multiple = False
+        return multiple
+
+    def call_api(self, cmd, data=None, check_rc=False, error_msg=None):
+        rc, stdout, stderr = self.module.run_command(cmd, data=data)
+        logger.debug("Received rc: %s" % rc)
+        logger.debug("stdout:")
+        logger.debug(stdout)
+        logger.debug("stderr:")
+        logger.debug(stderr)
+
+        if check_rc and rc != 0:
+            self.module.fail_json(msg=error_msg, stderr=stderr, stdout=stdout)
+
+        return rc, stdout, stderr
+
+    def create_from_template(self, template=None, template_path=None):
+        if template_path:
+            logger.debug("Create from template %s" % template_path)
+            error_msg = "Error Creating %s" % template_path
+            cmd = "%s create -f %s" % (self.target, template_path)
+            rc, stdout, stderr = self.call_api(cmd, check_rc=True, error_msg=error_msg)
+            return stdout
+
+        if template:
+            logger.debug("Create from template:")
+            formatted_template = json.dumps(template, sort_keys=False, indent=4, separators=(',', ':'))
+            logger.debug(formatted_template)
+            cmd = "%s create -f -" % self.target
+            rc, stdout, stderr = self.call_api(cmd, data=formatted_template, check_rc=True,
+                                               error_msg="Error creating from template.")
+            return stdout
+
+    def replace_from_template(self, template=None, template_path=None):
+        if template_path:
+            logger.debug("Replace from template %s" % template_path)
+            cmd = "%s replace -f %s" % (self.target, template_path)
+            error_msg = "Error replacing %s" % template_path
+            rc, stdout, stderr = self.call_api(cmd, check_rc=True, error_msg=error_msg)
+            return stdout
+        if template:
+            logger.debug("Replace from template:")
+            formatted_template = json.dumps(template, sort_keys=False, indent=4, separators=(',', ':'))
+            logger.debug(formatted_template)
+            cmd = "%s replace -f -" % self.target
+            rc, stdout, stderr = self.call_api(cmd, data=formatted_template, check_rc=True,
+                                               error_msg="Error replacing from template")
+            return stdout
+
+    def delete_resource(self, type, name):
+        cmd = "%s delete %s/%s" % (self.target, type, name)
+        logger.debug("exec: %s" % cmd)
+        error_msg = "Error deleting %s/%s" % (type, name)
+        rc, stdout, stderr = self.call_api(cmd, check_rc=True, error_msg=error_msg)
+        return stdout
+
+    def get_resource(self, type, name):
+        result = None
+        cmd = "%s get %s/%s -o json" % (self.target, type, name)
+        logger.debug("exec: %s" % cmd)
+        rc, stdout, stderr = self.call_api(cmd)
+        if rc == 0:
+            result = json.loads(stdout) 
+        elif rc != 0 and not re.search('not found', stderr):
+            error_msg = "Error getting %s/%s" % (type, name)
+            self.module.fail_json(msg=error_msg, stderr=stderr, stdout=stdout)
+        return result
+   
+    def set_context(self, context_name):
+        cmd = "%s user-context %s" % (self.target, context_name)
+        logger.debug("exec: %s" % cmd)
+        error_msg = "Error switching to context %s" % context_name
+        rc, stdout, stderr = self.call_api(cmd, check_rc=True, error_msg=error_msg)
+        return stdout
+
+    def set_project(self, project_name):
+        result = True
+        cmd = "%s project %s" % (self.target, project_name)
+        logger.debug("exec: %s" % cmd)
+        rc, stdout, stderr = self.call_api(cmd)
+        if rc != 0:
+            result = False
+            if not re.search('does not exist', stderr):
+                error_msg = "Error switching to project %s" % project_name
+                self.module.fail_json(msg=error_msg, stderr=stderr, stdout=stdout)
+        return result
+
+    def create_project(self, project_name):
+        result = True
+        cmd = "%s new-project %s" % (self.target, project_name)
+        logger.debug("exec: %s" % cmd)
+        error_msg = "Error creating project %s" % project_name
+        self.call_api(cmd, check_rc=True, error_msg=error_msg)
+        return result
+
+    def get_deployment(self, deployment_name):
+        cmd = "%s deploy %s" % (self.target, deployment_name)
+        logger.debug("exec: %s" % cmd)
+        rc, stdout, stderr = self.call_api(cmd)
+        if rc != 0:
+            if not re.search('not found', stderr):
+                error_msg = "Error getting deployment state %s" % deployment_name
+                self.module.fail_json(msg=error_msg, stderr=stderr, stdout=stdout)
+        return stdout
+
+
+def main():
+    manager = DeploymentManager()
+    manager.exec_module()
+
+if __name__ == '__main__':
+    main()

--- a/helloworld-ansibleapp/ansible/roles/helloworld-ansibleapp-openshift/library/oso_pvc.py
+++ b/helloworld-ansibleapp/ansible/roles/helloworld-ansibleapp-openshift/library/oso_pvc.py
@@ -1,0 +1,341 @@
+#!/usr/bin/python
+#
+# Copyright 2016 Ansible by Red Hat
+#
+# This file is part of ansible-container
+#
+
+DOCUMENTATION = '''
+
+module: oso_pvc
+
+short_description: Create or remove a persistent volume claim.
+
+description:
+  - Create or remove a persistent volume claim on an OpenShift cluster by setting the C(state) to I(present) or I(absent).
+  - The module is idempotent and will not replace an existing PVC unless the C(replace) option is passed.
+  - Supports check mode. Use check mode to view a list of actions the module will take.
+
+options:
+
+'''
+
+EXAMPLES = '''
+'''
+
+RETURN = '''
+'''
+import logging
+import logging.config
+
+from ansible.module_utils.basic import *
+
+logger = logging.getLogger('oso_pvc')
+
+LOGGING = (
+    {
+        'version': 1,
+        'disable_existing_loggers': True,
+        'handlers': {
+            'console': {
+                'level': 'DEBUG',
+                'class': 'logging.StreamHandler',
+            },
+            'file': {
+                'level': 'DEBUG',
+                'class': 'logging.FileHandler',
+                'filename': 'ansible-container.log'
+            }
+        },
+        'loggers': {
+            'oso_pvc': {
+                'handlers': ['file'],
+                'level': 'INFO',
+            },
+            'container': {
+                'handlers': ['file'],
+                'level': 'INFO',
+            },
+            'compose': {
+                'handlers': [],
+                'level': 'INFO'
+            },
+            'docker': {
+                'handlers': [],
+                'level': 'INFO'
+            }
+        },
+    }
+)
+
+
+class OSOPvcManager(object):
+
+    def __init__(self):
+
+        self.arg_spec = dict(
+            project_name=dict(type='str', aliases=['namespace'], required=True),
+            state=dict(type='str', choices=['present', 'absent'], default='present'),
+            name=dict(type='str', required=True),
+            annotations=dict(type='dict',),
+            access_modes=dict(type='list'),
+            requested_storage=dict(type='str', default='1Gi'),
+            match_labels=dict(type='dict',),
+            match_expressions=dict(type='list',),
+            volume_name=dict(type='str',),
+            replace=dict(type='bool', default=False),
+        )
+
+        self.module = AnsibleModule(self.arg_spec,
+                                    supports_check_mode=True)
+
+        self.project_name = None
+        self.state = None
+        self.name = None
+        self.annotations = None
+        self.access_modes = None
+        self.requested_storage = None
+        self.match_labels = None
+        self.match_expressions = None
+        self.volume_name = None
+        self.api = None
+        self.replace = None
+        self.check_mode = self.module.check_mode
+        self.debug = self.module._debug
+
+    def exec_module(self):
+
+        for key in self.arg_spec:
+            setattr(self, key, self.module.params.get(key))
+
+        if self.debug:
+            LOGGING['loggers']['container']['level'] = 'DEBUG'
+            LOGGING['loggers']['oso_pvc']['level'] = 'DEBUG'
+        logging.config.dictConfig(LOGGING)
+
+        self.api = OriginAPI(self.module)
+
+        actions = []
+        changed = False
+        claims = dict()
+        results = dict()
+
+        project_switch = self.api.set_project(self.project_name)
+        if not project_switch:
+            actions.append("Create project %s" % self.project_name)
+            if not self.check_mode:
+                self.api.create_project(self.project_name)
+
+        if self.state == 'present':
+            pvc = self.api.get_resource('pvc', self.name)
+            if not pvc:
+                template = self._create_template()
+                changed = True
+                actions.append("Create PVC %s" % self.name)
+                if not self.check_mode:
+                    self.api.create_from_template(template=template)
+            elif pvc and self.replace:
+                template = self._create_template()
+                changed = True
+                actions.append("Replace PVC %s" % self.name)
+                if not self.check_mode:
+                    self.api.replace_from_template(template=template)
+            claims[self.name.replace('-', '_') + '_pvc'] = self.api.get_resource('pvc', self.name)
+        elif self.state == 'absent':
+            if self.api.get_resource('pvc', self.name):
+                changed = True
+                actions.append("Delete PVC %s" % self.name)
+                if not self.check_mode:
+                    self.api.delete_resource('pvc', self.name)
+
+        results['changed'] = changed
+
+        if self.check_mode:
+            results['actions'] = actions
+
+        if claims:
+            results['ansible_facts'] = {u'volume_claims': claims}
+
+        self.module.exit_json(**results)
+
+    def _create_template(self):
+        '''
+        apiVersion: "v1"
+        kind: "PersistentVolumeClaim"
+        metadata:
+          name: "claim1"
+        spec:
+          accessModes:
+            - "ReadWriteOnce"
+          resources:
+            requests:
+              storage: "5Gi"
+          volumeName: "pv0001"
+        '''
+
+        template = dict(
+            apiVersion="v1",
+            kind="PersistentVolumeClaim",
+            metadata=dict(
+                name=self.name
+            ),
+            spec=dict()
+        )
+
+        if self.annotations:
+            template['metadata']['annotations'] = self.annotations
+        if self.access_modes:
+            template['spec']['accessModes'] = self.access_modes
+        if self.requested_storage:
+            template['spec']['resources'] = {u'requests': {u'storage': self.requested_storage}}
+        if self.match_labels:
+            if not template['spec'].get('selector'):
+                template['spec']['selector'] = {}
+            template['spec']['selector']['match_labels'] = self.match_labels
+        if self.match_expressions:
+            if not template['spec'].get('selector'):
+                template['spec']['selector'] = {}
+            template['spec']['selector']['match_expressions'] = self.match_expressions
+        if self.volume_name:
+            template['spec']['volumeName'] = self.volume_name
+
+        return template
+
+
+#The following will be included by `ansble-container shipit` when cloud modules are copied into the role library path.
+
+import re
+import json
+
+
+class OriginAPI(object):
+
+    def __init__(self, module, target="oc"):
+        self.target = target
+        self.module = module
+
+    @staticmethod
+    def use_multiple_deployments(services):
+        '''
+        Inspect services and return True if the app supports multiple replica sets.
+
+        :param services: list of docker-compose service dicts
+        :return: bool
+        '''
+        multiple = True
+        for service in services:
+            if not service.get('ports'):
+                multiple = False
+            if service.get('volumes_from'):
+                multiple = False
+        return multiple
+
+    def call_api(self, cmd, data=None, check_rc=False, error_msg=None):
+        rc, stdout, stderr = self.module.run_command(cmd, data=data)
+        logger.debug("Received rc: %s" % rc)
+        logger.debug("stdout:")
+        logger.debug(stdout)
+        logger.debug("stderr:")
+        logger.debug(stderr)
+
+        if check_rc and rc != 0:
+            self.module.fail_json(msg=error_msg, stderr=stderr, stdout=stdout)
+
+        return rc, stdout, stderr
+
+    def create_from_template(self, template=None, template_path=None):
+        if template_path:
+            logger.debug("Create from template %s" % template_path)
+            error_msg = "Error Creating %s" % template_path
+            cmd = "%s create -f %s" % (self.target, template_path)
+            rc, stdout, stderr = self.call_api(cmd, check_rc=True, error_msg=error_msg)
+            return stdout
+
+        if template:
+            logger.debug("Create from template:")
+            formatted_template = json.dumps(template, sort_keys=False, indent=4, separators=(',', ':'))
+            logger.debug(formatted_template)
+            cmd = "%s create -f -" % self.target
+            rc, stdout, stderr = self.call_api(cmd, data=formatted_template, check_rc=True,
+                                               error_msg="Error creating from template.")
+            return stdout
+
+    def replace_from_template(self, template=None, template_path=None):
+        if template_path:
+            logger.debug("Replace from template %s" % template_path)
+            cmd = "%s replace -f %s" % (self.target, template_path)
+            error_msg = "Error replacing %s" % template_path
+            rc, stdout, stderr = self.call_api(cmd, check_rc=True, error_msg=error_msg)
+            return stdout
+        if template:
+            logger.debug("Replace from template:")
+            formatted_template = json.dumps(template, sort_keys=False, indent=4, separators=(',', ':'))
+            logger.debug(formatted_template)
+            cmd = "%s replace -f -" % self.target
+            rc, stdout, stderr = self.call_api(cmd, data=formatted_template, check_rc=True,
+                                               error_msg="Error replacing from template")
+            return stdout
+
+    def delete_resource(self, type, name):
+        cmd = "%s delete %s/%s" % (self.target, type, name)
+        logger.debug("exec: %s" % cmd)
+        error_msg = "Error deleting %s/%s" % (type, name)
+        rc, stdout, stderr = self.call_api(cmd, check_rc=True, error_msg=error_msg)
+        return stdout
+
+    def get_resource(self, type, name):
+        result = None
+        cmd = "%s get %s/%s -o json" % (self.target, type, name)
+        logger.debug("exec: %s" % cmd)
+        rc, stdout, stderr = self.call_api(cmd)
+        if rc == 0:
+            result = json.loads(stdout) 
+        elif rc != 0 and not re.search('not found', stderr):
+            error_msg = "Error getting %s/%s" % (type, name)
+            self.module.fail_json(msg=error_msg, stderr=stderr, stdout=stdout)
+        return result
+   
+    def set_context(self, context_name):
+        cmd = "%s user-context %s" % (self.target, context_name)
+        logger.debug("exec: %s" % cmd)
+        error_msg = "Error switching to context %s" % context_name
+        rc, stdout, stderr = self.call_api(cmd, check_rc=True, error_msg=error_msg)
+        return stdout
+
+    def set_project(self, project_name):
+        result = True
+        cmd = "%s project %s" % (self.target, project_name)
+        logger.debug("exec: %s" % cmd)
+        rc, stdout, stderr = self.call_api(cmd)
+        if rc != 0:
+            result = False
+            if not re.search('does not exist', stderr):
+                error_msg = "Error switching to project %s" % project_name
+                self.module.fail_json(msg=error_msg, stderr=stderr, stdout=stdout)
+        return result
+
+    def create_project(self, project_name):
+        result = True
+        cmd = "%s new-project %s" % (self.target, project_name)
+        logger.debug("exec: %s" % cmd)
+        error_msg = "Error creating project %s" % project_name
+        self.call_api(cmd, check_rc=True, error_msg=error_msg)
+        return result
+
+    def get_deployment(self, deployment_name):
+        cmd = "%s deploy %s" % (self.target, deployment_name)
+        logger.debug("exec: %s" % cmd)
+        rc, stdout, stderr = self.call_api(cmd)
+        if rc != 0:
+            if not re.search('not found', stderr):
+                error_msg = "Error getting deployment state %s" % deployment_name
+                self.module.fail_json(msg=error_msg, stderr=stderr, stdout=stdout)
+        return stdout
+
+
+def main():
+    manager = OSOPvcManager()
+    manager.exec_module()
+
+if __name__ == '__main__':
+    main()

--- a/helloworld-ansibleapp/ansible/roles/helloworld-ansibleapp-openshift/library/oso_route.py
+++ b/helloworld-ansibleapp/ansible/roles/helloworld-ansibleapp-openshift/library/oso_route.py
@@ -1,0 +1,338 @@
+#!/usr/bin/python
+#
+# Copyright 2016 Ansible by Red Hat
+#
+# This file is part of ansible-container
+#
+
+DOCUMENTATION = '''
+
+module: k8s_route
+
+short_description: Create or remove a route on a Kubernetes or OpenShift cluster.
+
+description:
+  - Create or remove a route on a Kubernetes or OpenShift cluster by setting the C(state) to I(present) or I(absent).
+  - The module is idempotent and will not replace an existing route unless the C(reload) option is passed.
+  - Supports check mode. Use check mode to view a list of actions the module will take.
+
+options:
+
+'''
+
+EXAMPLES = '''
+'''
+
+RETURN = '''
+'''
+import logging
+import logging.config
+
+from ansible.module_utils.basic import *
+
+logger = logging.getLogger('oso_route')
+
+LOGGING = (
+    {
+        'version': 1,
+        'disable_existing_loggers': True,
+        'handlers': {
+            'console': {
+                'level': 'DEBUG',
+                'class': 'logging.StreamHandler',
+            },
+            'file': {
+                'level': 'DEBUG',
+                'class': 'logging.FileHandler',
+                'filename': 'ansible-container.log'
+            }
+        },
+        'loggers': {
+            'oso_route': {
+                'handlers': ['file'],
+                'level': 'DEBUG',
+            },
+            'container': {
+                'handlers': ['file'],
+                'level': 'DEBUG',
+            },
+            'compose': {
+                'handlers': [],
+                'level': 'INFO'
+            },
+            'docker': {
+                'handlers': [],
+                'level': 'INFO'
+            }
+        },
+    }
+)
+
+
+class RouteManager(object):
+
+    def __init__(self):
+
+        self.arg_spec = dict(
+            project_name=dict(type='str', aliases=['namespace']),
+            state=dict(type='str', choices=['present', 'absent'], default='present'),
+            labels=dict(type='dict'),
+            route_name=dict(type='str'),
+            host=dict(type='str'),
+            service_name=dict(type='str', required=True, aliases=['to']),
+            service_port=dict(type='str', required=True, aliases=['port']),
+            replace=dict(type='bool', default=False),
+            debug=dict(type='bool', default=False)
+        )
+
+        self.module = AnsibleModule(self.arg_spec,
+                                    supports_check_mode=True)
+
+        self.project_name = None
+        self.state = None
+        self.labels = None
+        self.route_name = None
+        self.host = None
+        self.service_name = None
+        self.service_port = None
+        self.replace = None
+        self.api = None
+        self.debug = None
+        self.check_mode = self.module.check_mode
+
+    def exec_module(self):
+
+        for key in self.arg_spec:
+            setattr(self, key, self.module.params.get(key))
+
+        if self.debug:
+            LOGGING['loggers']['container']['level'] = 'DEBUG'
+            LOGGING['loggers']['oso_route']['level'] = 'DEBUG'
+        logging.config.dictConfig(LOGGING)
+
+        self.api = OriginAPI(self.module)
+
+        actions = []
+        changed = False
+        routes = dict()
+        results = dict()
+
+        project_switch = self.api.set_project(self.project_name)
+        if not project_switch:
+            actions.append("Create project %s" % self.project_name)
+            if not self.check_mode:
+                self.api.create_project(self.project_name)
+
+        if self.state == 'present':
+            route = self.api.get_resource('route', self.route_name)
+            if not route:
+                template = self._create_template()
+                changed = True
+                actions.append("Create route %s" % self.route_name)
+                if not self.check_mode:
+                    self.api.create_from_template(template=template)
+            elif route and self.replace:
+                template = self._create_template()
+                changed = True
+                actions.append("Replace route %s" % self.route_name)
+                if not self.check_mode:
+                    self.api.replace_from_template(template=template)
+
+            routes[self.route_name.replace('-', '_') + '_route'] = self.api.get_resource('route', self.route_name)
+
+        elif self.state == 'absent':
+            if self.api.get_resource('route', self.route_name):
+                changed = True
+                actions.append("Delete route %s" % self.route_name)
+                if not self.check_mode:
+                    self.api.delete_resource('route', self.route_name)
+
+        results['changed'] = changed
+
+        if self.check_mode:
+            results['actions'] = actions
+
+        if routes:
+            results['ansible_facts'] = routes
+
+        self.module.exit_json(**results)
+
+    def _create_template(self):
+        '''
+        apiVersion: v1
+        kind: Route
+        metadata:
+          name: wordpress-wordpress
+          labels:
+            wordpress: wordpress
+        spec:
+          host: wordpress.local
+          to:
+            kind: Service
+            name: wordpress-wordpress
+          port:
+            targetPort: main
+        '''
+
+        template = dict(
+            apiVersion="v1",
+            kind="Route",
+            metadata=dict(
+                name=self.route_name,
+            ),
+            spec=dict(
+                to=dict(
+                    kind="Service",
+                    name=self.service_name
+                ),
+                port=dict(
+                    targetPort=self.service_port
+                )
+            )
+        )
+
+        if self.host:
+            template['spec']['host'] = self.host
+
+        if self.labels:
+            template['metadata']['labels'] = self.labels
+
+        return template
+
+#The following will be included by `ansble-container shipit` when cloud modules are copied into the role library path.
+
+import re
+import json
+
+
+class OriginAPI(object):
+
+    def __init__(self, module, target="oc"):
+        self.target = target
+        self.module = module
+
+    @staticmethod
+    def use_multiple_deployments(services):
+        '''
+        Inspect services and return True if the app supports multiple replica sets.
+
+        :param services: list of docker-compose service dicts
+        :return: bool
+        '''
+        multiple = True
+        for service in services:
+            if not service.get('ports'):
+                multiple = False
+            if service.get('volumes_from'):
+                multiple = False
+        return multiple
+
+    def call_api(self, cmd, data=None, check_rc=False, error_msg=None):
+        rc, stdout, stderr = self.module.run_command(cmd, data=data)
+        logger.debug("Received rc: %s" % rc)
+        logger.debug("stdout:")
+        logger.debug(stdout)
+        logger.debug("stderr:")
+        logger.debug(stderr)
+
+        if check_rc and rc != 0:
+            self.module.fail_json(msg=error_msg, stderr=stderr, stdout=stdout)
+
+        return rc, stdout, stderr
+
+    def create_from_template(self, template=None, template_path=None):
+        if template_path:
+            logger.debug("Create from template %s" % template_path)
+            error_msg = "Error Creating %s" % template_path
+            cmd = "%s create -f %s" % (self.target, template_path)
+            rc, stdout, stderr = self.call_api(cmd, check_rc=True, error_msg=error_msg)
+            return stdout
+
+        if template:
+            logger.debug("Create from template:")
+            formatted_template = json.dumps(template, sort_keys=False, indent=4, separators=(',', ':'))
+            logger.debug(formatted_template)
+            cmd = "%s create -f -" % self.target
+            rc, stdout, stderr = self.call_api(cmd, data=formatted_template, check_rc=True,
+                                               error_msg="Error creating from template.")
+            return stdout
+
+    def replace_from_template(self, template=None, template_path=None):
+        if template_path:
+            logger.debug("Replace from template %s" % template_path)
+            cmd = "%s replace -f %s" % (self.target, template_path)
+            error_msg = "Error replacing %s" % template_path
+            rc, stdout, stderr = self.call_api(cmd, check_rc=True, error_msg=error_msg)
+            return stdout
+        if template:
+            logger.debug("Replace from template:")
+            formatted_template = json.dumps(template, sort_keys=False, indent=4, separators=(',', ':'))
+            logger.debug(formatted_template)
+            cmd = "%s replace -f -" % self.target
+            rc, stdout, stderr = self.call_api(cmd, data=formatted_template, check_rc=True,
+                                               error_msg="Error replacing from template")
+            return stdout
+
+    def delete_resource(self, type, name):
+        cmd = "%s delete %s/%s" % (self.target, type, name)
+        logger.debug("exec: %s" % cmd)
+        error_msg = "Error deleting %s/%s" % (type, name)
+        rc, stdout, stderr = self.call_api(cmd, check_rc=True, error_msg=error_msg)
+        return stdout
+
+    def get_resource(self, type, name):
+        result = None
+        cmd = "%s get %s/%s -o json" % (self.target, type, name)
+        logger.debug("exec: %s" % cmd)
+        rc, stdout, stderr = self.call_api(cmd)
+        if rc == 0:
+            result = json.loads(stdout) 
+        elif rc != 0 and not re.search('not found', stderr):
+            error_msg = "Error getting %s/%s" % (type, name)
+            self.module.fail_json(msg=error_msg, stderr=stderr, stdout=stdout)
+        return result
+   
+    def set_context(self, context_name):
+        cmd = "%s user-context %s" % (self.target, context_name)
+        logger.debug("exec: %s" % cmd)
+        error_msg = "Error switching to context %s" % context_name
+        rc, stdout, stderr = self.call_api(cmd, check_rc=True, error_msg=error_msg)
+        return stdout
+
+    def set_project(self, project_name):
+        result = True
+        cmd = "%s project %s" % (self.target, project_name)
+        logger.debug("exec: %s" % cmd)
+        rc, stdout, stderr = self.call_api(cmd)
+        if rc != 0:
+            result = False
+            if not re.search('does not exist', stderr):
+                error_msg = "Error switching to project %s" % project_name
+                self.module.fail_json(msg=error_msg, stderr=stderr, stdout=stdout)
+        return result
+
+    def create_project(self, project_name):
+        result = True
+        cmd = "%s new-project %s" % (self.target, project_name)
+        logger.debug("exec: %s" % cmd)
+        error_msg = "Error creating project %s" % project_name
+        self.call_api(cmd, check_rc=True, error_msg=error_msg)
+        return result
+
+    def get_deployment(self, deployment_name):
+        cmd = "%s deploy %s" % (self.target, deployment_name)
+        logger.debug("exec: %s" % cmd)
+        rc, stdout, stderr = self.call_api(cmd)
+        if rc != 0:
+            if not re.search('not found', stderr):
+                error_msg = "Error getting deployment state %s" % deployment_name
+                self.module.fail_json(msg=error_msg, stderr=stderr, stdout=stdout)
+        return stdout
+
+
+def main():
+    manager = RouteManager()
+    manager.exec_module()
+
+if __name__ == '__main__':
+    main()

--- a/helloworld-ansibleapp/ansible/roles/helloworld-ansibleapp-openshift/library/oso_service.py
+++ b/helloworld-ansibleapp/ansible/roles/helloworld-ansibleapp-openshift/library/oso_service.py
@@ -1,0 +1,346 @@
+#!/usr/bin/python
+#
+# Copyright 2016 Ansible by Red Hat
+#
+# This file is part of ansible-container
+#
+
+DOCUMENTATION = '''
+
+module: oso_service
+
+short_description: Create or remove a service on a Kubernetes or OpenShift cluster.
+
+description:
+  - Create or remove a service on a Kubernetes or OpenShift cluster by setting the C(state) to I(present) or I(absent).
+  - The module is idempotent and will not replace an existing service unless the C(reload) option is passed.
+  - Supports check mode. Use check mode to view a list of actions the module will take.
+
+options:
+
+'''
+
+EXAMPLES = '''
+'''
+
+RETURN = '''
+'''
+import logging
+import logging.config
+
+from ansible.module_utils.basic import *
+
+logger = logging.getLogger('oso_service')
+
+LOGGING = (
+    {
+        'version': 1,
+        'disable_existing_loggers': True,
+        'handlers': {
+            'console': {
+                'level': 'DEBUG',
+                'class': 'logging.StreamHandler',
+            },
+            'file': {
+                'level': 'DEBUG',
+                'class': 'logging.FileHandler',
+                'filename': 'ansible-container.log'
+            }
+        },
+        'loggers': {
+            'oso_service': {
+                'handlers': ['file'],
+                'level': 'INFO',
+            },
+            'container': {
+                'handlers': ['file'],
+                'level': 'INFO',
+            },
+            'compose': {
+                'handlers': [],
+                'level': 'INFO'
+            },
+            'docker': {
+                'handlers': [],
+                'level': 'INFO'
+            }
+        },
+    }
+)
+
+
+class OSOServiceManager(object):
+
+    def __init__(self):
+
+        self.arg_spec = dict(
+            project_name=dict(type='str', aliases=['namespace'], required=True),
+            state=dict(type='str', choices=['present', 'absent'], default='present'),
+            labels=dict(type='dict'),
+            ports=dict(type='list', required=True),
+            service_name=dict(type='str', required=True),
+            loadbalancer=dict(type='bool', default=False),
+            replace=dict(type='bool', default=False),
+            selector=dict(type='dict', required=True),
+            debug=dict(type='bool', default=False)
+        )
+
+        self.module = AnsibleModule(self.arg_spec,
+                                    supports_check_mode=True)
+
+        self.project_name = None
+        self.state = None
+        self.labels = None
+        self.ports = None
+        self.service_name = None
+        self.loadbalancer = None
+        self.selector = None
+        self.replace = None
+        self.api = None
+        self.debug = None
+        self.check_mode = self.module.check_mode
+
+    def exec_module(self):
+
+        for key in self.arg_spec:
+            setattr(self, key, self.module.params.get(key))
+
+        if self.debug:
+            LOGGING['loggers']['container']['level'] = 'DEBUG'
+            LOGGING['loggers']['oso_service']['level'] = 'DEBUG'
+        logging.config.dictConfig(LOGGING)
+
+        self.api = OriginAPI(self.module)
+
+        actions = []
+        changed = False
+        services = dict()
+        results = dict()
+
+        project_switch = self.api.set_project(self.project_name)
+        if not project_switch:
+            actions.append("Create project %s" % self.project_name)
+            if not self.check_mode:
+                self.api.create_project(self.project_name)
+
+        if self.state == 'present':
+            service = self.api.get_resource('service', self.service_name)
+            if not service:
+                template = self._create_template()
+                changed = True
+                actions.append("Create service %s" % self.service_name)
+                if not self.check_mode:
+                    self.api.create_from_template(template=template)
+            elif service and self.replace:
+                template = self._create_template()
+                changed = True
+                actions.append("Replace service %s" % self.service_name)
+                if not self.check_mode:
+                    self.api.replace_from_template(template=template)
+            services[self.service_name.replace('-', '_') + '_service'] = self.api.get_resource('service', self.service_name)
+        elif self.state == 'absent':
+            if self.api.get_resource('service', self.service_name):
+                changed = True
+                actions.append("Delete service %s" % self.service_name)
+                if not self.check_mode:
+                    self.api.delete_resource('service', self.service_name)
+
+        results['changed'] = changed
+
+        if self.check_mode:
+            results['actions'] = actions
+
+        if services:
+            results['ansible_facts'] = services
+
+        self.module.exit_json(**results)
+
+    def _create_template(self):
+        '''
+        apiVersion: v1
+            kind: Service
+            metadata:
+              name: frontend
+              labels:
+                app: guestbook
+                tier: frontend
+            spec:
+              # if your cluster supports it, uncomment the following to automatically create
+              # an external load-balanced IP for the frontend service.
+              # type: LoadBalancer
+              ports:
+                # the port that this service should serve on
+              - port: 80
+              selector:
+                app: guestbook
+                tier: frontend
+        '''
+
+        selector = self.selector if self.selector else self.service_name
+        self._update_ports()
+
+        template = dict(
+            apiVersion="v1",
+            kind="Service",
+            metadata=dict(
+                name=self.service_name
+            ),
+            spec=dict(
+                selector=selector,
+                ports=self.ports
+            )
+        )
+
+        if self.labels:
+            template['metadata']['labels'] = self.labels
+
+        if self.loadbalancer:
+            template['spec']['type'] = 'LoadBalancer'
+
+        return template
+
+    def _update_ports(self):
+        count = 0
+        for port in self.ports:
+            if not port.get('name'):
+                port['name'] = "port%s" % count
+                count += 1
+
+
+#The following will be included by `ansble-container shipit` when cloud modules are copied into the role library path.
+
+import re
+import json
+
+
+class OriginAPI(object):
+
+    def __init__(self, module, target="oc"):
+        self.target = target
+        self.module = module
+
+    @staticmethod
+    def use_multiple_deployments(services):
+        '''
+        Inspect services and return True if the app supports multiple replica sets.
+
+        :param services: list of docker-compose service dicts
+        :return: bool
+        '''
+        multiple = True
+        for service in services:
+            if not service.get('ports'):
+                multiple = False
+            if service.get('volumes_from'):
+                multiple = False
+        return multiple
+
+    def call_api(self, cmd, data=None, check_rc=False, error_msg=None):
+        rc, stdout, stderr = self.module.run_command(cmd, data=data)
+        logger.debug("Received rc: %s" % rc)
+        logger.debug("stdout:")
+        logger.debug(stdout)
+        logger.debug("stderr:")
+        logger.debug(stderr)
+
+        if check_rc and rc != 0:
+            self.module.fail_json(msg=error_msg, stderr=stderr, stdout=stdout)
+
+        return rc, stdout, stderr
+
+    def create_from_template(self, template=None, template_path=None):
+        if template_path:
+            logger.debug("Create from template %s" % template_path)
+            error_msg = "Error Creating %s" % template_path
+            cmd = "%s create -f %s" % (self.target, template_path)
+            rc, stdout, stderr = self.call_api(cmd, check_rc=True, error_msg=error_msg)
+            return stdout
+
+        if template:
+            logger.debug("Create from template:")
+            formatted_template = json.dumps(template, sort_keys=False, indent=4, separators=(',', ':'))
+            logger.debug(formatted_template)
+            cmd = "%s create -f -" % self.target
+            rc, stdout, stderr = self.call_api(cmd, data=formatted_template, check_rc=True,
+                                               error_msg="Error creating from template.")
+            return stdout
+
+    def replace_from_template(self, template=None, template_path=None):
+        if template_path:
+            logger.debug("Replace from template %s" % template_path)
+            cmd = "%s replace -f %s" % (self.target, template_path)
+            error_msg = "Error replacing %s" % template_path
+            rc, stdout, stderr = self.call_api(cmd, check_rc=True, error_msg=error_msg)
+            return stdout
+        if template:
+            logger.debug("Replace from template:")
+            formatted_template = json.dumps(template, sort_keys=False, indent=4, separators=(',', ':'))
+            logger.debug(formatted_template)
+            cmd = "%s replace -f -" % self.target
+            rc, stdout, stderr = self.call_api(cmd, data=formatted_template, check_rc=True,
+                                               error_msg="Error replacing from template")
+            return stdout
+
+    def delete_resource(self, type, name):
+        cmd = "%s delete %s/%s" % (self.target, type, name)
+        logger.debug("exec: %s" % cmd)
+        error_msg = "Error deleting %s/%s" % (type, name)
+        rc, stdout, stderr = self.call_api(cmd, check_rc=True, error_msg=error_msg)
+        return stdout
+
+    def get_resource(self, type, name):
+        result = None
+        cmd = "%s get %s/%s -o json" % (self.target, type, name)
+        logger.debug("exec: %s" % cmd)
+        rc, stdout, stderr = self.call_api(cmd)
+        if rc == 0:
+            result = json.loads(stdout) 
+        elif rc != 0 and not re.search('not found', stderr):
+            error_msg = "Error getting %s/%s" % (type, name)
+            self.module.fail_json(msg=error_msg, stderr=stderr, stdout=stdout)
+        return result
+   
+    def set_context(self, context_name):
+        cmd = "%s user-context %s" % (self.target, context_name)
+        logger.debug("exec: %s" % cmd)
+        error_msg = "Error switching to context %s" % context_name
+        rc, stdout, stderr = self.call_api(cmd, check_rc=True, error_msg=error_msg)
+        return stdout
+
+    def set_project(self, project_name):
+        result = True
+        cmd = "%s project %s" % (self.target, project_name)
+        logger.debug("exec: %s" % cmd)
+        rc, stdout, stderr = self.call_api(cmd)
+        if rc != 0:
+            result = False
+            if not re.search('does not exist', stderr):
+                error_msg = "Error switching to project %s" % project_name
+                self.module.fail_json(msg=error_msg, stderr=stderr, stdout=stdout)
+        return result
+
+    def create_project(self, project_name):
+        result = True
+        cmd = "%s new-project %s" % (self.target, project_name)
+        logger.debug("exec: %s" % cmd)
+        error_msg = "Error creating project %s" % project_name
+        self.call_api(cmd, check_rc=True, error_msg=error_msg)
+        return result
+
+    def get_deployment(self, deployment_name):
+        cmd = "%s deploy %s" % (self.target, deployment_name)
+        logger.debug("exec: %s" % cmd)
+        rc, stdout, stderr = self.call_api(cmd)
+        if rc != 0:
+            if not re.search('not found', stderr):
+                error_msg = "Error getting deployment state %s" % deployment_name
+                self.module.fail_json(msg=error_msg, stderr=stderr, stdout=stdout)
+        return stdout
+
+
+def main():
+    manager = OSOServiceManager()
+    manager.exec_module()
+
+if __name__ == '__main__':
+    main()

--- a/helloworld-ansibleapp/ansible/roles/helloworld-ansibleapp-openshift/tasks/main.yml
+++ b/helloworld-ansibleapp/ansible/roles/helloworld-ansibleapp-openshift/tasks/main.yml
@@ -1,0 +1,69 @@
+---
+
+- name: Create Project 
+  command: oc new-project helloworld-ansibleapp
+  ignore_errors: True
+
+- name: Select Project
+  command: oc project helloworld-ansibleapp
+
+- oso_service:
+    service_name: web
+    project_name: helloworld-ansibleapp
+    labels:
+      app: helloworld-ansibleapp
+      service: web
+    ports:
+    - name: port-8080
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: helloworld-ansibleapp
+      service: web
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- oso_route:
+    project_name: helloworld-ansibleapp
+    service_port: port-8080
+    labels:
+      app: helloworld-ansibleapp
+      service: web
+    route_name: web-8080
+    replace: true
+    service_name: web
+    state: present
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- oso_deployment:
+    project_name: helloworld-ansibleapp
+    labels:
+      app: helloworld-ansibleapp
+      service: web
+    deployment_name: web
+    containers:
+    - securityContext: {}
+      name: web
+      env:
+        MESSAGE: '{{ message }}'
+      args:
+      - /usr/sbin/nginx
+      - -c
+      - /opt/app-root/etc/nginx.conf
+      command:
+      - /usr/bin/entrypoint
+      image: ansibleapp/helloworld-ansibleapp-web:latest
+      ports:
+      - containerPort: 8080
+        protocol: TCP
+    replace: true
+  register: output
+
+- debug: var=output
+  when: playbook_debug

--- a/helloworld-ansibleapp/ansible/shipit-openshift.yml
+++ b/helloworld-ansibleapp/ansible/shipit-openshift.yml
@@ -1,0 +1,7 @@
+- name: Deploy helloworld-ansibleapp to  openshift
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  roles:
+  - role: helloworld-ansibleapp-openshift
+    playbook_debug: false

--- a/helloworld-ansibleapp/ansible/templates/entrypoint.j2
+++ b/helloworld-ansibleapp/ansible/templates/entrypoint.j2
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set +x 
+USER_ID=$(id -u)
+if [ {{ uid }} != ${USER_ID} ]; then
+sed "s@{{ username }}:x:\${USER_ID}:@{{ username }}:x:${USER_ID}:@g" {{ app_root }}/etc/passwd.template > /etc/passwd
+fi
+
+echo "${MESSAGE}" > {{ app_root }}/html/index.html
+
+exec "$@"

--- a/helloworld-ansibleapp/ansible/templates/nginx.conf.j2
+++ b/helloworld-ansibleapp/ansible/templates/nginx.conf.j2
@@ -1,0 +1,48 @@
+worker_processes auto;
+
+daemon off;
+
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 2048;
+
+    client_body_temp_path /tmp 1 2;
+    client_body_buffer_size 256k;
+    client_body_in_file_only off;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    server {
+        listen       8080 default_server;
+        server_name  _;
+        root         {{ app_root }}/html;
+
+
+        location / {
+        }
+
+        error_page 404 /404.html;
+            location = /40x.html {
+        }
+
+        error_page 500 502 503 504 /50x.html;
+            location = /50x.html {
+        }
+    }
+}
+

--- a/helloworld-ansibleapp/ansible/vars.yml
+++ b/helloworld-ansibleapp/ansible/vars.yml
@@ -1,0 +1,5 @@
+---
+app_root: "/opt/app-root"
+username: "nginx"
+uid: "10001"
+

--- a/helloworld-ansibleapp/ansibleapp.yml
+++ b/helloworld-ansibleapp/ansibleapp.yml
@@ -1,0 +1,9 @@
+id: 35ead4e8-cf1f-4909-bb1b-b981f4eb3142
+name: ansibleapp/helloworld-ansibleapp
+description: Hello World nginx 
+bindable: false
+async: "unsupported"
+parameters:
+  - name: message 
+    description: say something to nginx 
+    type: string

--- a/helloworld-ansibleapp/ansibleapp/actions/provision.yaml
+++ b/helloworld-ansibleapp/ansibleapp/actions/provision.yaml
@@ -1,0 +1,7 @@
+- name: Deploy helloworld-ansibleapp to  openshift
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  roles:
+  - role: helloworld-ansibleapp-openshift
+    playbook_debug: false


### PR DESCRIPTION
This PR adds the ability to run ansibleapp(-base) containers under OpenShift
using the restricted scc and arbitrary uid support.  These changes were based on [existing work](https://github.com/RHsyseng/container-rhel-examples/tree/master/starter-arbitrary-uid)

The helloworld nginx example also runs in restricted scc with arbitrary uid support.
It was used to testing the ansibleapp-base modifications.

Testing:

- Building the images, running `helloworld-ansibleapp` via docker
[![building and docker run test](https://asciinema.org/a/111877.png)](https://asciinema.org/a/111877)
[script while testing above](https://gist.github.com/jcpowermac/aa73a5e4734836da0a026dc41d867e1b)

- Using the ansible-service-broker to test running `helloworld-ansibleapp`
[![asb testing](https://asciinema.org/a/111884.png)](https://asciinema.org/a/111884)